### PR TITLE
Attempting to make the "\\s*" -> "\\s+" into a pull request

### DIFF
--- a/grammars/jolie.cson
+++ b/grammars/jolie.cson
@@ -49,7 +49,7 @@ repository:
     match: "\\b(constants|cH|instanceof|execution|comp|concurrent|nullProcess|single|sequential|main|init|cset|is_defined|embedded|extender|courier|forward|install|undef|include|synchronized|throws)\\b"
   keywords_control:
     name: "keyword.control.jolie"
-    match: "\\b(if|while|for|foreach|forward|scope)\\b"
+    match: "\\b(if|while|for|foreach|throw|forward|scope)\\b"
   keywords_types:
     name: "storage.type.jolie"
     match: "\\b(void|bool|int|string|long|double|raw)\\b"

--- a/grammars/jolie.cson
+++ b/grammars/jolie.cson
@@ -36,7 +36,7 @@ repository:
     end: "\\*/"
     name: "comment.block.jolie"
   definitions:
-    match: "\\b(inputPort|outputPort|interface|type|define|service)\\s*(\\w+)\\b"
+    match: "\\b(inputPort|outputPort|interface|type|define|service)\\s+(\\w+)\\b"
     captures: {
       "1": { name: "keyword.other.jolie" },
       "2": { name: "meta.class.identifier.jolie" }


### PR DESCRIPTION
It's the change such that variables with names which have keywords as prefixes are not halfway highlighted as keywords. The git history may have become a bit tangly (GitHub forks for every change suggestion made on the website it seems).
